### PR TITLE
Mobile-first redesign: compact header, footer attribution, AI bottom sheet, OpenRouter fallback

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -32,72 +32,63 @@ body {
 #app-container {
     max-width: 1400px;
     margin: 0 auto;
-    padding-bottom: 4rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
 }
 
 // ─── Header ──────────────────────────────────────────────────────────────────
 .app-header {
     background: linear-gradient(180deg, #0d1520 0%, $bg 100%);
     border-bottom: 1px solid $border-subtle;
-    padding: 1.25rem 1.5rem 0;
+    // Compact on mobile
+    padding: 0.75rem 1rem 0.75rem;
+
+    @media (min-width: 640px) {
+        padding: 1.1rem 1.5rem 1.1rem;
+    }
 
     .header-top {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1rem;
-        flex-wrap: wrap;
+        gap: 0.75rem;
 
         .logos {
             display: flex;
             align-items: center;
-            gap: 1.5rem;
+            gap: 1rem;
 
             .app-logo {
-                height: 40px;
+                height: 32px;
                 width: auto;
+
+                @media (min-width: 640px) {
+                    height: 40px;
+                }
             }
 
+            // Hide TMDB logo in header on mobile — it appears in the footer
             .tmdb-logo {
-                height: 20px;
+                display: none;
+                height: 18px;
                 width: auto;
                 opacity: 0.85;
+
+                @media (min-width: 640px) {
+                    display: block;
+                }
             }
         }
 
         .header-actions {
             display: flex;
             align-items: center;
-            gap: 0.75rem;
-        }
-    }
+            gap: 0.5rem;
 
-    .attribution-bar {
-        margin-top: 0.75rem;
-        padding: 0.5rem 0;
-        border-top: 1px solid $border-subtle;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-size: 0.72rem;
-        color: $text-dim;
-
-        a {
-            color: $secondary;
-            text-decoration: none;
-            &:hover { text-decoration: underline; }
-        }
-
-        .tmdb-badge {
-            display: flex;
-            align-items: center;
-            gap: 0.35rem;
-            background: rgba($secondary, 0.08);
-            border: 1px solid rgba($secondary, 0.2);
-            border-radius: 20px;
-            padding: 0.2rem 0.6rem;
-            font-size: 0.68rem;
-            color: $secondary;
+            @media (min-width: 640px) {
+                gap: 0.75rem;
+            }
         }
     }
 }
@@ -106,17 +97,23 @@ body {
 .ai-trigger-btn {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.35rem;
     background: linear-gradient(135deg, #4f46e5, #7c3aed);
     color: #fff;
     border: none;
     border-radius: 20px;
-    padding: 0.45rem 1rem;
+    padding: 0.4rem 0.75rem;
     font-family: $font;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     font-weight: 600;
     cursor: pointer;
     transition: opacity 0.2s, transform 0.15s;
+    white-space: nowrap;
+
+    @media (min-width: 640px) {
+        padding: 0.45rem 1rem;
+        font-size: 0.8rem;
+    }
 
     &:hover {
         opacity: 0.9;
@@ -134,13 +131,19 @@ body {
     border-radius: $radius-sm;
     color: $text-muted;
     font-family: $font;
-    font-size: 0.8rem;
-    padding: 0.45rem 0.9rem;
+    font-size: 0.78rem;
+    padding: 0.4rem 0.7rem;
     cursor: pointer;
     display: flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.3rem;
     transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+
+    @media (min-width: 640px) {
+        font-size: 0.8rem;
+        padding: 0.45rem 0.9rem;
+    }
 
     &:hover { background: $border; color: $text; }
 
@@ -159,11 +162,16 @@ body {
     background: $surface-raised;
     border: 1px solid $border;
     border-radius: $radius;
-    padding: 1.25rem;
-    margin: 0.5rem 1.5rem;
-    font-size: 0.85rem;
+    padding: 1rem;
+    margin-top: 0.5rem;
+    font-size: 0.83rem;
     color: $text-muted;
     line-height: 1.6;
+
+    @media (min-width: 640px) {
+        padding: 1.25rem;
+        margin: 0.5rem 0;
+    }
 
     a {
         color: $primary;
@@ -173,7 +181,7 @@ body {
 
     img {
         display: block;
-        height: 28px;
+        height: 24px;
         width: auto;
         margin-top: 1rem;
         opacity: 0.8;
@@ -182,7 +190,11 @@ body {
 
 // ─── Search ───────────────────────────────────────────────────────────────────
 .search-section {
-    padding: 1.5rem 1.5rem 0;
+    padding: 1rem 1rem 0;
+
+    @media (min-width: 640px) {
+        padding: 1.5rem 1.5rem 0;
+    }
 }
 
 .search-form {
@@ -200,7 +212,7 @@ body {
     }
 
     .search-icon {
-        padding: 0 0.75rem 0 1rem;
+        padding: 0 0.6rem 0 0.85rem;
         color: $text-dim;
         display: flex;
         align-items: center;
@@ -216,7 +228,7 @@ body {
         color: $text;
         font-family: $font;
         font-size: 0.95rem;
-        padding: 0.85rem 0.5rem;
+        padding: 0.8rem 0.5rem;
         outline: none;
         min-width: 0;
 
@@ -243,12 +255,16 @@ body {
         color: #fff;
         border: none;
         font-family: $font;
-        font-size: 0.9rem;
+        font-size: 0.88rem;
         font-weight: 600;
-        padding: 0.85rem 1.5rem;
+        padding: 0.8rem 1.1rem;
         cursor: pointer;
         transition: background 0.2s;
         flex-shrink: 0;
+
+        @media (min-width: 640px) {
+            padding: 0.85rem 1.5rem;
+        }
 
         &:hover { background: #019fc9; }
         &:focus-visible { outline: 2px solid $primary; outline-offset: -2px; }
@@ -257,19 +273,24 @@ body {
 
 // ─── Filters ──────────────────────────────────────────────────────────────────
 .filters-section {
-    padding: 1rem 1.5rem;
+    padding: 0.75rem 1rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
     flex-wrap: wrap;
 
+    @media (min-width: 640px) {
+        padding: 1rem 1.5rem;
+        gap: 0.5rem;
+    }
+
     .filter-label {
-        font-size: 0.78rem;
+        font-size: 0.75rem;
         color: $text-dim;
         font-weight: 500;
         text-transform: uppercase;
         letter-spacing: 0.06em;
-        margin-right: 0.25rem;
+        margin-right: 0.2rem;
     }
 
     .filter-pill {
@@ -278,11 +299,15 @@ body {
         border-radius: 20px;
         color: $text-muted;
         font-family: $font;
-        font-size: 0.82rem;
+        font-size: 0.8rem;
         font-weight: 500;
-        padding: 0.35rem 0.9rem;
+        padding: 0.3rem 0.75rem;
         cursor: pointer;
         transition: all 0.2s;
+
+        @media (min-width: 640px) {
+            padding: 0.35rem 0.9rem;
+        }
 
         &:hover { border-color: $primary; color: $primary; }
 
@@ -297,7 +322,12 @@ body {
 
 // ─── Results section ──────────────────────────────────────────────────────────
 #results-container {
-    padding: 0 1.5rem;
+    padding: 0 1rem;
+    flex: 1;
+
+    @media (min-width: 640px) {
+        padding: 0 1.5rem;
+    }
 }
 
 .results-header {
@@ -324,11 +354,16 @@ body {
 // ─── Cards ────────────────────────────────────────────────────────────────────
 .item-card {
     display: flex;
-    gap: 1rem;
-    padding: 1rem 0;
+    gap: 0.85rem;
+    padding: 0.85rem 0;
     border-bottom: 1px solid $border-subtle;
     transition: background 0.2s;
     border-radius: $radius-sm;
+
+    @media (min-width: 640px) {
+        gap: 1rem;
+        padding: 1rem 0;
+    }
 
     &:hover {
         background: rgba($surface, 0.6);
@@ -336,15 +371,24 @@ body {
 
     .card-image-div {
         flex-shrink: 0;
-        width: 92px;
+        width: 80px;
+
+        @media (min-width: 480px) {
+            width: 92px;
+        }
 
         img {
-            width: 92px;
-            height: 138px;
+            width: 80px;
+            height: 120px;
             object-fit: cover;
             border-radius: $radius-sm;
             background: $surface-raised;
             display: block;
+
+            @media (min-width: 480px) {
+                width: 92px;
+                height: 138px;
+            }
         }
     }
 
@@ -353,15 +397,15 @@ body {
         min-width: 0;
         display: flex;
         flex-direction: column;
-        gap: 0.4rem;
+        gap: 0.35rem;
     }
 }
 
 // ─── Card header ──────────────────────────────────────────────────────────────
 .card-header-div {
     .card-title {
-        margin: 0 0 0.3rem;
-        font-size: 1rem;
+        margin: 0 0 0.25rem;
+        font-size: 0.95rem;
         font-weight: 600;
         color: $text;
         line-height: 1.3;
@@ -381,7 +425,7 @@ body {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        font-size: 0.78rem;
+        font-size: 0.75rem;
         color: $text-muted;
         flex-wrap: wrap;
     }
@@ -392,8 +436,8 @@ body {
         background: $surface-raised;
         border: 1px solid $border;
         border-radius: 4px;
-        padding: 0.1rem 0.45rem;
-        font-size: 0.72rem;
+        padding: 0.1rem 0.4rem;
+        font-size: 0.68rem;
         font-weight: 600;
         color: $secondary;
         text-transform: uppercase;
@@ -403,7 +447,7 @@ body {
 
 // ─── Card text ────────────────────────────────────────────────────────────────
 .card-text-div {
-    font-size: 0.83rem;
+    font-size: 0.82rem;
     color: $text-muted;
     line-height: 1.5;
     overflow: hidden;
@@ -418,7 +462,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 0.75rem;
     margin-top: auto;
 
     .card-ratings-div {
@@ -427,22 +471,26 @@ body {
         gap: 0.5rem;
 
         .rating-score {
-            font-size: 0.78rem;
+            font-size: 0.75rem;
             color: $text-muted;
 
             strong {
                 font-weight: 700;
                 color: $text;
-                font-size: 0.85rem;
+                font-size: 0.82rem;
             }
         }
 
         .card-ratings-bar {
-            width: 60px;
+            width: 48px;
             height: 4px;
             background: $surface-raised;
             border-radius: 2px;
             overflow: hidden;
+
+            @media (min-width: 480px) {
+                width: 60px;
+            }
 
             .card-ratings-color {
                 height: 100%;
@@ -459,16 +507,21 @@ body {
     .no-trailer-button {
         display: inline-flex;
         align-items: center;
-        gap: 0.4rem;
+        gap: 0.35rem;
         border-radius: 20px;
-        padding: 0.35rem 0.85rem;
+        padding: 0.3rem 0.7rem;
         font-family: $font;
-        font-size: 0.78rem;
+        font-size: 0.75rem;
         font-weight: 600;
         border: none;
         cursor: pointer;
         white-space: nowrap;
         transition: all 0.2s;
+
+        @media (min-width: 480px) {
+            padding: 0.35rem 0.85rem;
+            font-size: 0.78rem;
+        }
 
         .play-icon {
             width: 0;
@@ -549,6 +602,8 @@ body {
 }
 
 // ─── AI recommendations panel ─────────────────────────────────────────────────
+// Mobile: full-width bottom sheet (slides up from bottom edge)
+// Tablet+: centered modal
 #ai-panel {
     position: fixed;
     inset: 0;
@@ -558,46 +613,64 @@ body {
     align-items: flex-end;
     justify-content: center;
     z-index: 900;
-    padding: 1rem;
+    // No padding on mobile so sheet goes edge-to-edge
+    padding: 0;
     animation: fadeIn 0.2s ease;
 
     @media (min-width: 640px) {
         align-items: center;
+        padding: 1rem;
     }
 
     .ai-panel-card {
         background: $surface;
         border: 1px solid $border;
-        border-radius: $radius-lg;
+        // Rounded top corners only on mobile (bottom sheet style)
+        border-radius: $radius-lg $radius-lg 0 0;
         width: 100%;
-        max-width: 600px;
-        max-height: 85dvh;
+        max-width: 100%;
+        // 90% of viewport height on mobile for comfortable reach
+        max-height: 90dvh;
         display: flex;
         flex-direction: column;
         overflow: hidden;
         animation: slideUp 0.25s ease;
 
+        @media (min-width: 640px) {
+            max-width: 600px;
+            max-height: 85dvh;
+            border-radius: $radius-lg;
+        }
+
         .ai-panel-header {
-            padding: 1.25rem 1.5rem 1rem;
+            padding: 1rem 1.25rem 0.85rem;
             border-bottom: 1px solid $border-subtle;
             display: flex;
             align-items: flex-start;
             justify-content: space-between;
             gap: 1rem;
 
+            @media (min-width: 640px) {
+                padding: 1.25rem 1.5rem 1rem;
+            }
+
             .ai-panel-title {
                 h2 {
                     margin: 0 0 0.2rem;
-                    font-size: 1.1rem;
+                    font-size: 1rem;
                     font-weight: 700;
                     background: linear-gradient(135deg, #818cf8, #a78bfa);
                     -webkit-background-clip: text;
                     -webkit-text-fill-color: transparent;
+
+                    @media (min-width: 640px) {
+                        font-size: 1.1rem;
+                    }
                 }
 
                 p {
                     margin: 0;
-                    font-size: 0.78rem;
+                    font-size: 0.75rem;
                     color: $text-dim;
                 }
             }
@@ -622,24 +695,35 @@ body {
         }
 
         .ai-panel-body {
-            padding: 1.25rem 1.5rem;
+            padding: 1rem 1.25rem;
             overflow-y: auto;
             flex: 1;
+            // Safe area inset for devices with home bars
+            padding-bottom: max(1rem, env(safe-area-inset-bottom));
+
+            @media (min-width: 640px) {
+                padding: 1.25rem 1.5rem;
+            }
 
             .ai-context-note {
                 background: rgba(#4f46e5, 0.08);
                 border: 1px solid rgba(#4f46e5, 0.2);
                 border-radius: $radius-sm;
-                padding: 0.75rem 1rem;
-                font-size: 0.8rem;
+                padding: 0.65rem 0.85rem;
+                font-size: 0.79rem;
                 color: #a5b4fc;
                 margin-bottom: 1rem;
             }
 
             .ai-prompt-row {
                 display: flex;
+                flex-direction: column;
                 gap: 0.5rem;
-                margin-bottom: 1.25rem;
+                margin-bottom: 1.1rem;
+
+                @media (min-width: 480px) {
+                    flex-direction: row;
+                }
 
                 textarea {
                     flex: 1;
@@ -652,7 +736,7 @@ body {
                     padding: 0.6rem 0.75rem;
                     resize: none;
                     outline: none;
-                    min-height: 60px;
+                    min-height: 56px;
                     transition: border-color 0.2s;
 
                     &::placeholder { color: $text-dim; }
@@ -664,14 +748,21 @@ body {
                     color: #fff;
                     border: none;
                     border-radius: $radius-sm;
-                    padding: 0.6rem 1rem;
+                    padding: 0.7rem 1rem;
                     font-family: $font;
-                    font-size: 0.82rem;
+                    font-size: 0.85rem;
                     font-weight: 600;
                     cursor: pointer;
                     white-space: nowrap;
-                    align-self: flex-start;
+                    // Full-width on mobile, auto on wider screens
+                    width: 100%;
                     transition: opacity 0.2s;
+
+                    @media (min-width: 480px) {
+                        width: auto;
+                        align-self: flex-start;
+                        padding: 0.6rem 1rem;
+                    }
 
                     &:hover { opacity: 0.88; }
                     &:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -681,7 +772,7 @@ body {
             .ai-loading {
                 text-align: center;
                 color: $text-dim;
-                padding: 2rem 0;
+                padding: 1.5rem 0;
                 font-size: 0.88rem;
 
                 .ai-spinner {
@@ -702,28 +793,29 @@ body {
                 padding: 0.75rem 1rem;
                 font-size: 0.82rem;
                 color: #fca5a5;
+                word-break: break-word;
             }
 
             .ai-results {
                 display: flex;
                 flex-direction: column;
-                gap: 0.75rem;
+                gap: 0.65rem;
 
                 .ai-result-item {
                     background: $surface-raised;
                     border: 1px solid $border;
                     border-radius: $radius-sm;
-                    padding: 0.85rem 1rem;
+                    padding: 0.8rem 0.9rem;
 
                     .ai-result-title {
                         font-weight: 600;
-                        font-size: 0.92rem;
+                        font-size: 0.9rem;
                         color: $text;
-                        margin-bottom: 0.3rem;
+                        margin-bottom: 0.25rem;
                     }
 
                     .ai-result-desc {
-                        font-size: 0.8rem;
+                        font-size: 0.79rem;
                         color: $text-muted;
                         line-height: 1.5;
                     }
@@ -732,7 +824,7 @@ body {
 
             .ai-disclaimer {
                 margin-top: 1rem;
-                font-size: 0.7rem;
+                font-size: 0.68rem;
                 color: $text-dim;
                 text-align: center;
             }
@@ -743,16 +835,27 @@ body {
 // ─── Loading skeleton ─────────────────────────────────────────────────────────
 .skeleton-card {
     display: flex;
-    gap: 1rem;
-    padding: 1rem 0;
+    gap: 0.85rem;
+    padding: 0.85rem 0;
     border-bottom: 1px solid $border-subtle;
 
+    @media (min-width: 640px) {
+        gap: 1rem;
+        padding: 1rem 0;
+    }
+
     .skeleton-image {
-        width: 92px;
-        height: 138px;
+        width: 80px;
+        height: 120px;
         border-radius: $radius-sm;
         background: $surface-raised;
         animation: shimmer 1.4s ease infinite;
+        flex-shrink: 0;
+
+        @media (min-width: 480px) {
+            width: 92px;
+            height: 138px;
+        }
     }
 
     .skeleton-content {
@@ -776,6 +879,37 @@ body {
     }
 }
 
+// ─── Footer ──────────────────────────────────────────────────────────────────
+.app-footer {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 1rem;
+    border-top: 1px solid $border-subtle;
+    font-size: 0.72rem;
+    color: $text-dim;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+
+    @media (min-width: 640px) {
+        padding: 1.25rem 1.5rem;
+        font-size: 0.75rem;
+    }
+
+    .footer-tmdb-logo {
+        height: 14px;
+        width: auto;
+        opacity: 0.7;
+        flex-shrink: 0;
+    }
+
+    a {
+        color: $secondary;
+        text-decoration: none;
+        &:hover { text-decoration: underline; }
+    }
+}
+
 // ─── Animations ──────────────────────────────────────────────────────────────
 @keyframes fadeIn {
     from { opacity: 0; }
@@ -783,7 +917,7 @@ body {
 }
 
 @keyframes slideUp {
-    from { transform: translateY(30px); opacity: 0; }
+    from { transform: translateY(40px); opacity: 0; }
     to   { transform: translateY(0); opacity: 1; }
 }
 
@@ -797,14 +931,13 @@ body {
     100% { opacity: 0.5; }
 }
 
-// ─── Responsive ───────────────────────────────────────────────────────────────
+// ─── Responsive (tablet+) ─────────────────────────────────────────────────────
 @media (min-width: 768px) {
     .item-card {
-        .card-image-div img {
+        .card-image-div {
             width: 110px;
-            height: 165px;
+            img { width: 110px; height: 165px; }
         }
-        .card-image-div { width: 110px; }
     }
 
     .card-header-div .card-title { font-size: 1.05rem; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Results from "./components/Results";
 import AIRecommendations from "./components/AIRecommendations";
 import { getApiConfiguration, getTrending, searchMulti } from "./services";
 import { useConfigContext } from "./context";
+import tmdbLogo from "./assets/tmdb_logo.svg";
 
 function App() {
     const [results, setResults] = useState<ResultItem[]>();
@@ -65,6 +66,29 @@ function App() {
                     searchContext={query}
                 />
             )}
+            <footer className="app-footer">
+                <img src={tmdbLogo} alt="TMDB" className="footer-tmdb-logo" />
+                <span>
+                    This product uses the TMDB API but is not endorsed or
+                    certified by{" "}
+                    <a
+                        href="https://www.themoviedb.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        TMDb
+                    </a>
+                    . Data and images subject to their{" "}
+                    <a
+                        href="https://www.themoviedb.org/documentation/api/terms-of-use"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        terms of use
+                    </a>
+                    .
+                </span>
+            </footer>
         </div>
     );
 }

--- a/src/api/openrouterClient.ts
+++ b/src/api/openrouterClient.ts
@@ -1,5 +1,15 @@
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
-const MODEL = "meta-llama/llama-3.2-3b-instruct:free";
+
+// Ordered list of free models. OpenRouter will try each in sequence if one is
+// rate-limited or unavailable, so a transient 429 on one provider won't fail
+// the whole request.
+const FREE_MODELS = [
+    "meta-llama/llama-3.2-3b-instruct:free",
+    "meta-llama/llama-3.1-8b-instruct:free",
+    "qwen/qwen-2.5-7b-instruct:free",
+    "google/gemma-2-9b-it:free",
+    "mistralai/mistral-7b-instruct:free",
+];
 
 export async function getAiRecommendations(
     context: string,
@@ -30,7 +40,10 @@ Respond ONLY with a valid JSON array — no markdown fences, no explanation — 
             "X-Title": "Movie Finder Widget",
         },
         body: JSON.stringify({
-            model: MODEL,
+            // Pass all models with route:"fallback" so OpenRouter automatically
+            // tries the next model if the current one is rate-limited (429).
+            models: FREE_MODELS,
+            route: "fallback",
             messages: [
                 { role: "system", content: systemPrompt },
                 { role: "user", content: userMessage },

--- a/src/components/AIRecommendations.tsx
+++ b/src/components/AIRecommendations.tsx
@@ -61,7 +61,7 @@ const AIRecommendations = ({
                             >
                                 OpenRouter
                             </a>{" "}
-                            · Llama 3.2
+                            · free models
                         </p>
                     </div>
                     <button

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -11,7 +11,7 @@ const LogoHeader = ({ onAiClick }: { onAiClick: () => void }) => {
                 <div className="logos">
                     <img
                         src={logo}
-                        alt="Movie Finder Widget"
+                        alt="Movie Finder"
                         className="app-logo"
                     />
                     <img
@@ -26,7 +26,8 @@ const LogoHeader = ({ onAiClick }: { onAiClick: () => void }) => {
                         onClick={onAiClick}
                         aria-label="Open AI recommendations"
                     >
-                        <span className="sparkle">✨</span> AI Picks
+                        <span className="sparkle">✨</span>
+                        <span className="ai-btn-label">AI Picks</span>
                     </button>
                     <button
                         className={`about-btn${aboutOpen ? " open" : ""}`}
@@ -36,33 +37,6 @@ const LogoHeader = ({ onAiClick }: { onAiClick: () => void }) => {
                         About <span className="chevron" />
                     </button>
                 </div>
-            </div>
-
-            <div className="attribution-bar">
-                <span className="tmdb-badge">
-                    <img src={tmdbLogo} alt="TMDB" style={{ height: 12 }} />
-                    Powered by TMDB
-                </span>
-                <span>
-                    This product uses the TMDB API but is not endorsed or
-                    certified by{" "}
-                    <a
-                        href="https://www.themoviedb.org/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        TMDb
-                    </a>
-                    . Data and images subject to their{" "}
-                    <a
-                        href="https://www.themoviedb.org/documentation/api/terms-of-use"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        terms of use
-                    </a>
-                    .
-                </span>
             </div>
 
             {aboutOpen && (


### PR DESCRIPTION
- Header: remove busy attribution bar; hide TMDB logo on mobile (shown in footer); reduce padding and font sizes for small screens
- Footer: move TMDB API attribution to a dedicated footer (satisfies TOS, clears header clutter)
- AI panel: redesign as a bottom sheet on mobile (edge-to-edge, rounded top corners, safe-area inset), stacked textarea+button on narrow viewports, centered modal on tablet+
- OpenRouter: replace single hardcoded model with a prioritised list of 5 free models using route:"fallback" so a 429 on one provider automatically retries the next
- Update AI panel subtitle from "Llama 3.2" to "free models" to reflect dynamic selection

https://claude.ai/code/session_01TYHYy99eLvdbU84kVBzYhd