### PR TITLE
Fix AI picker: reduce models array to 3 items for OpenRouter compatibility

### DIFF
--- a/src/api/openrouterClient.ts
+++ b/src/api/openrouterClient.ts
@@ -5,9 +5,7 @@ const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 // the whole request.
 const FREE_MODELS = [
     "meta-llama/llama-3.2-3b-instruct:free",
-    "meta-llama/llama-3.1-8b-instruct:free",
     "qwen/qwen-2.5-7b-instruct:free",
-    "google/gemma-2-9b-it:free",
     "mistralai/mistral-7b-instruct:free",
 ];
 


### PR DESCRIPTION
OpenRouter's API requires the 'models' array to have 3 items or fewer.
Trimmed FREE_MODELS from 5 entries down to 3, keeping a diverse set of
fallback models (Llama, Qwen, Mistral).

https://claude.ai/code/session_01LTcQti9JqLoZrMJXyMRYMe