### PR TITLE
Add server-side filtering and responsive pagination

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -886,6 +886,111 @@ body {
     }
 }
 
+// ─── Pagination (desktop) ─────────────────────────────────────────────────────
+// Hidden on mobile — mobile uses infinite scroll / load-more instead.
+.pagination {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    padding: 1.25rem 0 0.5rem;
+
+    @media (min-width: 640px) {
+        display: flex;
+    }
+
+    .pagination-btn {
+        background: $surface;
+        border: 1px solid $border;
+        border-radius: $radius-sm;
+        color: $text-muted;
+        font-family: $font;
+        font-size: 0.85rem;
+        min-width: 2.1rem;
+        height: 2.1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 0.45rem;
+        cursor: pointer;
+        transition: background 0.2s, border-color 0.2s, color 0.2s;
+        line-height: 1;
+
+        &:hover:not(:disabled) {
+            border-color: $primary;
+            color: $primary;
+        }
+
+        &.active {
+            background: rgba($primary, 0.12);
+            border-color: $primary;
+            color: $primary;
+            font-weight: 600;
+            cursor: default;
+        }
+
+        &:disabled {
+            opacity: 0.35;
+            cursor: not-allowed;
+        }
+
+        &.pagination-arrow {
+            font-size: 1.2rem;
+        }
+    }
+
+    .pagination-ellipsis {
+        color: $text-dim;
+        padding: 0 0.2rem;
+        font-size: 0.85rem;
+        line-height: 2.1rem;
+        pointer-events: none;
+    }
+}
+
+// ─── Load-more / infinite-scroll (mobile) ─────────────────────────────────────
+// Shown only on mobile; desktop sees numbered pagination above.
+.load-more-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem 0;
+    gap: 0.5rem;
+
+    @media (min-width: 640px) {
+        display: none;
+    }
+
+    .load-more-btn {
+        background: $surface;
+        border: 1px solid $border;
+        border-radius: $radius;
+        color: $text-muted;
+        font-family: $font;
+        font-size: 0.85rem;
+        font-weight: 500;
+        padding: 0.55rem 1.75rem;
+        cursor: pointer;
+        transition: border-color 0.2s, color 0.2s;
+
+        &:hover:not(:disabled) {
+            border-color: $primary;
+            color: $primary;
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+
+    .load-more-info {
+        font-size: 0.75rem;
+        color: $text-dim;
+    }
+}
+
 // ─── Footer ──────────────────────────────────────────────────────────────────
 .app-footer {
     display: flex;
@@ -957,7 +1062,9 @@ body {
         grid-template-columns: 1fr 1fr;
         column-gap: 1.5rem;
 
-        .results-header { grid-column: 1 / -1; }
+        .results-header,
+        .pagination,
+        .load-more-container { grid-column: 1 / -1; }
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,36 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./App.scss";
 import LogoHeader from "./components/LogoHeader";
 import SearchBar from "./components/SearchBar";
 import FilterOptions from "./components/FilterOptions";
 import Results from "./components/Results";
 import AIRecommendations from "./components/AIRecommendations";
-import { getApiConfiguration, getTrending, searchMulti } from "./services";
+import { getApiConfiguration, getTrending, searchByFilter } from "./services";
 import { useConfigContext } from "./context";
 import tmdbLogo from "./assets/tmdb_logo.svg";
 
 function App() {
-    const [results, setResults] = useState<ResultItem[]>();
+    const [results, setResults] = useState<ResultItem[] | undefined>();
     const [trendingResults, setTrendingResults] = useState<ResultItem[]>();
     const [page, setPage] = useState<number>(1);
+    const [totalPages, setTotalPages] = useState<number>(0);
     const [query, setQuery] = useState<string>("");
     const [filter, setFilter] = useState<FilterCategory>("all");
     const [total, setTotal] = useState<number>();
     const [loading, setLoading] = useState(false);
+    const [loadingMore, setLoadingMore] = useState(false);
     const [aiOpen, setAiOpen] = useState(false);
     const { setImageUrl } = useConfigContext();
+
+    // When true the next fetch will append results (mobile load-more).
+    // Using a ref avoids it becoming a stale-closure issue in the effect.
+    const appendRef = useRef(false);
+
+    // Reset append mode whenever the query or filter changes so a fresh search
+    // always replaces the result list instead of appending to it.
+    useEffect(() => {
+        appendRef.current = false;
+    }, [query, filter]);
 
     // Fetch trending + API config on mount
     useEffect(() => {
@@ -32,33 +44,81 @@ function App() {
             .finally(() => setLoading(false));
     }, [setImageUrl]);
 
-    // Fetch search results when query or page changes
+    // Fetch search results when query, filter, or page changes
     useEffect(() => {
         if (!query) {
             setResults(undefined);
+            setTotal(undefined);
+            setTotalPages(0);
             return;
         }
-        setLoading(true);
-        searchMulti(query, page)
+        const isAppend = appendRef.current;
+        if (isAppend) {
+            setLoadingMore(true);
+        } else {
+            setLoading(true);
+        }
+        searchByFilter(query, page, filter)
             .then((response) => {
                 setTotal(response.total_results);
-                setResults(response.results);
+                setTotalPages(response.total_pages);
+                if (isAppend) {
+                    setResults((prev) => [
+                        ...(prev ?? []),
+                        ...response.results,
+                    ]);
+                } else {
+                    setResults(response.results);
+                }
             })
             .catch(console.error)
-            .finally(() => setLoading(false));
-    }, [query, page]);
+            .finally(() => {
+                setLoading(false);
+                setLoadingMore(false);
+            });
+    }, [query, filter, page]);
+
+    /** Filter change — resets to page 1 and replaces results. */
+    const handleFilterChange = (newFilter: FilterCategory) => {
+        appendRef.current = false;
+        setFilter(newFilter);
+        setPage(1);
+    };
+
+    /** Mobile infinite-scroll / load-more: appends the next page. */
+    const handleLoadMore = () => {
+        if (page < totalPages && !loadingMore && !loading) {
+            appendRef.current = true;
+            setPage((p) => p + 1);
+        }
+    };
+
+    /** Desktop numbered pagination: replaces results and scrolls to top. */
+    const handlePageChange = (newPage: number) => {
+        appendRef.current = false;
+        setPage(newPage);
+        window.scrollTo({ top: 0, behavior: "smooth" });
+    };
 
     return (
         <div id="app-container">
             <LogoHeader onAiClick={() => setAiOpen(true)} />
             <SearchBar query={query} setQuery={setQuery} setPage={setPage} />
-            <FilterOptions setFilter={setFilter} currentFilter={filter} />
+            <FilterOptions
+                setFilter={handleFilterChange}
+                currentFilter={filter}
+            />
             <Results
                 results={results ?? trendingResults}
                 filter={filter}
                 total={total ?? trendingResults?.length}
+                totalPages={totalPages}
+                page={page}
                 loading={loading}
+                loadingMore={loadingMore}
                 query={query}
+                onLoadMore={handleLoadMore}
+                onPageChange={handlePageChange}
             />
             {aiOpen && (
                 <AIRecommendations

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,71 @@
+/** Returns page numbers and "…" placeholders for a compact paginator. */
+function buildPageList(current: number, total: number): (number | "…")[] {
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+    const pages: (number | "…")[] = [1];
+    if (current > 3) pages.push("…");
+    const start = Math.max(2, current - 1);
+    const end = Math.min(total - 1, current + 1);
+    for (let p = start; p <= end; p++) pages.push(p);
+    if (current < total - 2) pages.push("…");
+    pages.push(total);
+    return pages;
+}
+
+const Pagination = ({
+    page,
+    totalPages,
+    onPageChange,
+}: {
+    page: number;
+    totalPages: number;
+    onPageChange: (page: number) => void;
+}) => {
+    if (totalPages <= 1) return null;
+    const pages = buildPageList(page, totalPages);
+
+    return (
+        <nav className="pagination" aria-label="Search results pages">
+            <button
+                className="pagination-btn pagination-arrow"
+                onClick={() => onPageChange(page - 1)}
+                disabled={page === 1}
+                aria-label="Previous page"
+            >
+                ‹
+            </button>
+
+            {pages.map((p, i) =>
+                p === "…" ? (
+                    <span
+                        key={`ellipsis-${i}`}
+                        className="pagination-ellipsis"
+                        aria-hidden="true"
+                    >
+                        …
+                    </span>
+                ) : (
+                    <button
+                        key={p}
+                        className={`pagination-btn${p === page ? " active" : ""}`}
+                        onClick={() => onPageChange(p)}
+                        aria-label={`Page ${p}`}
+                        aria-current={p === page ? "page" : undefined}
+                    >
+                        {p}
+                    </button>
+                )
+            )}
+
+            <button
+                className="pagination-btn pagination-arrow"
+                onClick={() => onPageChange(page + 1)}
+                disabled={page === totalPages}
+                aria-label="Next page"
+            >
+                ›
+            </button>
+        </nav>
+    );
+};
+
+export default Pagination;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from "react";
 import ItemCard from "./ItemCard";
+import Pagination from "./Pagination";
 import TrailerPanel from "./TrailerPanel";
 
 const SkeletonCard = () => (
@@ -18,19 +20,52 @@ const Results = ({
     results,
     filter,
     total,
+    totalPages,
+    page,
     loading,
+    loadingMore,
     query,
+    onLoadMore,
+    onPageChange,
 }: {
     results?: ResultItem[];
     filter: FilterCategory;
     total?: number;
+    totalPages: number;
+    page: number;
     loading?: boolean;
+    loadingMore?: boolean;
     query: string;
+    onLoadMore: () => void;
+    onPageChange: (page: number) => void;
 }) => {
+    // Server-side filtering is used for non-"all" filters, but keep as a
+    // safety guard in case any mixed results slip through on the "all" endpoint.
     const filtered = results?.filter(
         (item) => filter === "all" || item.media_type === filter
     );
     const displayCount = filtered?.length ?? 0;
+    const hasMore = page < totalPages;
+
+    // IntersectionObserver sentinel for mobile infinite scroll
+    const sentinelRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const sentinel = sentinelRef.current;
+        if (!sentinel || !hasMore || loadingMore || loading || !query) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting) {
+                    onLoadMore();
+                }
+            },
+            // Only auto-trigger on mobile via rootMargin; desktop uses click pagination
+            { rootMargin: "300px" }
+        );
+        observer.observe(sentinel);
+        return () => observer.disconnect();
+    }, [hasMore, loadingMore, loading, query, onLoadMore]);
 
     return (
         <section id="results-container">
@@ -57,6 +92,38 @@ const Results = ({
                 : filtered?.map((item) => (
                       <ItemCard key={`${item.media_type}-${item.id}`} item={item} />
                   ))}
+
+            {/* ── Mobile: infinite scroll sentinel + load-more fallback ── */}
+            {query && !loading && (
+                <div className="load-more-container">
+                    {/* Sentinel triggers IntersectionObserver */}
+                    <div ref={sentinelRef} className="infinite-scroll-sentinel" />
+
+                    {hasMore ? (
+                        <button
+                            className="load-more-btn"
+                            onClick={onLoadMore}
+                            disabled={loadingMore}
+                            aria-label="Load more results"
+                        >
+                            {loadingMore ? "Loading…" : "Load more"}
+                        </button>
+                    ) : (
+                        filtered && filtered.length > 0 && (
+                            <span className="load-more-info">All results loaded</span>
+                        )
+                    )}
+                </div>
+            )}
+
+            {/* ── Desktop: numbered pagination ── */}
+            {query && !loading && totalPages > 1 && (
+                <Pagination
+                    page={page}
+                    totalPages={totalPages}
+                    onPageChange={onPageChange}
+                />
+            )}
 
             <TrailerPanel />
         </section>

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,18 +1,42 @@
 import tmdbClient from "./api/tmdbClient";
+
+type SearchResponse = {
+    results: ResultItem[];
+    total_results: number;
+    total_pages: number;
+};
+
 export const getTrending = async (
     timePeriod: "week" | "day" = "week"
 ): Promise<ApiResponse<"results", ResultItem[]>> =>
     (await tmdbClient.get(`/trending/all/${timePeriod}`)).data;
 
-export const searchMulti = async (
+export const searchByFilter = async (
     query: string,
-    page: number
-): Promise<{ results: ResultItem[]; total_results: number }> =>
-    (
+    page: number,
+    filter: FilterCategory
+): Promise<SearchResponse> => {
+    if (filter === "all") {
+        return (
+            await tmdbClient.get(
+                `/search/multi?language=en-US&query=${encodeURIComponent(query)}&page=${page}&include_adult=false`
+            )
+        ).data;
+    }
+    const data = (
         await tmdbClient.get(
-            `/search/multi?language=en-US&query=${query}&page=${page}&include_adult=false`
+            `/search/${filter}?language=en-US&query=${encodeURIComponent(query)}&page=${page}&include_adult=false`
         )
     ).data;
+    // Type-specific endpoints omit media_type, so inject it
+    return {
+        ...data,
+        results: (data.results as ResultItem[]).map((item) => ({
+            ...item,
+            media_type: filter,
+        })),
+    };
+};
 
 export const getApiConfiguration = async (): Promise<
     ApiResponse<"images", ApiConfiguration>


### PR DESCRIPTION
- Route filter-specific searches through dedicated TMDB endpoints
  (/search/movie, /search/tv, /search/person) so pagination counts are
  accurate per type; the "All" filter continues to use /search/multi
- Desktop (≥640px): numbered pagination with prev/next arrows and
  ellipsis-collapsed page ranges; clicking a page scrolls to top
- Mobile (<640px): IntersectionObserver infinite scroll with a "Load more"
  fallback button; results accumulate via appendRef so new searches/filter
  changes always reset to a fresh list
- Pagination and load-more container span full grid width on ≥1200px layouts

https://claude.ai/code/session_017nWD8VgXo134kKREFr1H4H